### PR TITLE
[fix] Private uploaded files

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -75,7 +75,7 @@ location __PATH__/ {
   # Handle private files through Drupal. Private file's path can come
   # with a language prefix.
   location ~ ^(/[a-z\-]+)?/system/files/ {
-    try_files $uri /index.php?$query_string;
+    rewrite ^((/[a-z\-]+)?/system/files/(.+))$ /index.php?q=$1 last;
   }
 
   location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {


### PR DESCRIPTION
## Problem
Private file uploaded with webforms are not reachable:
https://domain.tld/system/files/webform/IMAGE.jpeg

## Solution
Use rewrite to do it

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [x] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/drupal7_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/drupal7_ynh%20PR-NUM-%20(USERNAME)/)  
